### PR TITLE
Log4J to SLF4J polish details on displayName, description, decompose tests, etc.

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/slf4j/Log4jToSlf4j.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/Log4jToSlf4j.java
@@ -27,7 +27,6 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Stack;
@@ -35,29 +34,17 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Use of the traditional Log4J to SLF4J bridge can result in some
- * loss of performance as the Log4j 2 Messages must be formatted
- * before they can be passed to SLF4J.
- * <p>
- * todo
+ * @see <a href="http://www.slf4j.org/migrator.html">SLF4J Migrator</a>
  */
 public class Log4jToSlf4j extends Recipe {
-    private static final MethodMatcher GET_LOGGER_MATCHER = new MethodMatcher("org.apache.log4j.Logger getLogger(..)");
-    private static final MethodMatcher GET_LOGGER_WITH_MANAGER_MATCHER = new MethodMatcher("org.apache.log4j.LogManager getLogger(..)");
-
-    @Override // todo
+    @Override
     public String getDisplayName() {
-        return "Log4jToSlf4j";
-    }
-
-    @Override // todo
-    public String getDescription() {
-        return "TODO.";
+        return "Migrate Log4j to SLF4J";
     }
 
     @Override
-    protected TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new Log4jToSlf4jVisitor();
+    public String getDescription() {
+        return "Use of the traditional Log4J to SLF4J bridge can result in some loss of performance as the Log4j 2 Messages must be formatted before they can be passed to SLF4J.";
     }
 
     @Override
@@ -65,7 +52,15 @@ public class Log4jToSlf4j extends Recipe {
         return new UsesType<>("org.apache.log4j.Logger");
     }
 
-    private class Log4jToSlf4jVisitor extends JavaIsoVisitor<ExecutionContext> {
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new Log4jToSlf4jVisitor();
+    }
+
+    private static class Log4jToSlf4jVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private static final MethodMatcher GET_LOGGER_MATCHER = new MethodMatcher("org.apache.log4j.Logger getLogger(..)");
+        private static final MethodMatcher GET_LOGGER_WITH_MANAGER_MATCHER = new MethodMatcher("org.apache.log4j.LogManager getLogger(..)");
+
         private final List<MethodMatcher> logLevelMatchers = Stream.of("trace", "debug", "info", "warn", "error", "fatal")
                 .map(level -> "org.apache.log4j." + (level.equals("trace") ? "Logger" : "Category") +
                         " " + level + "(..)")

--- a/src/main/resources/META-INF/rewrite/slf4j.yml
+++ b/src/main/resources/META-INF/rewrite/slf4j.yml
@@ -15,7 +15,7 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.logging.logback.Log4JToSLF4J
+name: org.openrewrite.java.logging.slf4j.Log4JToSLF4J
 displayName: Migrate Log4J logging framework to SLF4J
 description: Migrates Log4J logging framework to SLF4J.
 tags:
@@ -25,4 +25,3 @@ tags:
 recipeList:
   - org.openrewrite.java.logging.slf4j.Log4jToSlf4j
   - org.openrewrite.java.logging.slf4j.ParameterizedLogging
-

--- a/src/test/kotlin/org/openrewrite/java/logging/slf4j/ParameterizedLogging.kt
+++ b/src/test/kotlin/org/openrewrite/java/logging/slf4j/ParameterizedLogging.kt
@@ -53,8 +53,8 @@ class ParameterizedLoggingTest : JavaRecipeTest {
             import org.slf4j.Logger;
             import org.slf4j.LoggerFactory;
 
-            class A {
-                Logger logger = LoggerFactory.getLogger(A.class);
+            class Test {
+                Logger logger = LoggerFactory.getLogger(Test.class);
 
                 void asInteger(String numberString) {
                     String name = "Jon";
@@ -72,8 +72,8 @@ class ParameterizedLoggingTest : JavaRecipeTest {
             import org.slf4j.Logger;
             import org.slf4j.LoggerFactory;
 
-            class A {
-                Logger logger = LoggerFactory.getLogger(A.class);
+            class Test {
+                Logger logger = LoggerFactory.getLogger(Test.class);
 
                 void asInteger(String numberString) {
                     String name = "Jon";


### PR DESCRIPTION
part of https://github.com/openrewrite/rewrite-logging/issues/16

Adds content for log4j to slf4j recipe, breaks down tests further into discrete slices