### PR TITLE
Compose log4j-to-slf4j from smaller recipes

### DIFF
--- a/src/main/resources/META-INF/rewrite/slf4j.yml
+++ b/src/main/resources/META-INF/rewrite/slf4j.yml
@@ -15,12 +15,11 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.logging.slf4j.Log4JToSLF4J
-displayName: Migrate Log4J logging framework to SLF4J
-description: Migrates Log4J logging framework to SLF4J.
+name: org.openrewrite.java.logging.slf4j.SLF4JBestPractices
+displayName: SLF4J best practices
+description: Applies best practices to SLF4J logging.
 tags:
   - logging
-  - log4j
   - slf4j
 recipeList:
   - org.openrewrite.java.logging.slf4j.Log4jToSlf4j

--- a/src/test/kotlin/org/openrewrite/java/logging/slf4j/Log4jToSlf4jTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/logging/slf4j/Log4jToSlf4jTest.kt
@@ -76,7 +76,7 @@ class Log4jToSlf4jTest : JavaRecipeTest {
     )
 
     @Test
-    fun objectParametersUseToString() = assertChanged(
+    fun objectParametersToString() = assertChanged(
         before = """
             import org.apache.log4j.Logger;
 


### PR DESCRIPTION
closes https://github.com/openrewrite/rewrite-logging/issues/16
see: https://github.com/openrewrite/rewrite-logging/pull/21

Break the `Log4jToSlf4j` recipe into smaller, individual recipes.
